### PR TITLE
Change key skills items display to flexbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,11 @@
 				</ul>
 			</div>
 		</section>
+
+		<div class="footer">
+
+		</div>
+
 	</div>
 </div>
 </body>

--- a/style.css
+++ b/style.css
@@ -149,6 +149,10 @@ section {
 	margin-bottom: 3px;
 }
 
+.footer {
+	padding-top: 20px;
+}
+
 @media all and (max-width: 800px) {
 	#headshot {
 		display: none;

--- a/style.css
+++ b/style.css
@@ -16,6 +16,10 @@ p {
 	color: #444;
 }
 
+ul {
+	padding-inline-start: 0px;
+}
+
 #cv {
 	width: 90%;
 	max-width: 800px;

--- a/style.css
+++ b/style.css
@@ -135,23 +135,23 @@ section {
 }
 
 .keySkills {
+	display: flex;
+	flex-wrap: wrap;
+
 	list-style-type: none;
-	column-count:3;
 	font-size: 1em;
 	color: #444;
 }
 
-.keySkills ul li {
+.keySkills li {
+	width: 150px;
+	margin-right: 8px;
 	margin-bottom: 3px;
 }
 
 @media all and (max-width: 800px) {
 	#headshot {
 		display: none;
-	}
-	
-	.keySkills {
-  	column-count:2;
 	}
 }
 
@@ -199,10 +199,6 @@ section {
 	
 	#mainArea {
 		padding: 0 25px;
-	}
-	
-	.keySkills {
-  	column-count:1;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -137,7 +137,6 @@ section {
 .keySkills {
 	list-style-type: none;
 	column-count:3;
-	margin-bottom: 20px;
 	font-size: 1em;
 	color: #444;
 }


### PR DESCRIPTION
Hey @aarongable,
I just browsed your repo and wanted to suggest these changes as you are using flexbox

* Lets have flexbox do the work of breaking items in smaller screens. So, I added a css property in `.keySkills li` to list items having a `width: 150px` with `margin-right: 8px`.
* To have consistency of style in `sections`, I removed `margin-bottom` from `keySkills` and added a dummy footer with `padding: 20px`
(Please refer commits for detailed changes)